### PR TITLE
Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dwlb
+config.h
 *.o
 wlr-layer-shell-unstable-v1-protocol.c
 wlr-layer-shell-unstable-v1-protocol.h

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation -g
 
 all: $(BINS)
 
+config.h:
+	cp config.def.h $@
+
 clean:
 	$(RM) $(BINS) $(addsuffix .o,$(BINS))
 
@@ -44,7 +47,7 @@ wlr-layer-shell-unstable-v1-protocol.c:
 
 wlr-layer-shell-unstable-v1-protocol.o: wlr-layer-shell-unstable-v1-protocol.h
 
-dwlb.o: utf8.h xdg-shell-protocol.h xdg-output-unstable-v1-protocol.h wlr-layer-shell-unstable-v1-protocol.h
+dwlb.o: utf8.h config.h xdg-shell-protocol.h xdg-output-unstable-v1-protocol.h wlr-layer-shell-unstable-v1-protocol.h
 
 # Protocol dependencies
 dwlb: xdg-shell-protocol.o xdg-output-unstable-v1-protocol.o wlr-layer-shell-unstable-v1-protocol.o

--- a/config.def.h
+++ b/config.def.h
@@ -1,0 +1,17 @@
+// bar properties
+static bool hidden = false;
+static bool bottom = false;
+static bool hide_vacant = false;
+
+// define the number of tags and the tag names, if the number of tags is
+//  greater than TAGSLEN they will not be displayed, each tag also needs a name
+#define TAGSLEN 9
+static char *tags[TAGSLEN] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+
+// set colors for bar
+// TODO: explain the formatting? or at least how a hex color code would be translated
+static pixman_color_t activecolor = { .red = 0x0000, .green = 0x5555, .blue = 0x7777, .alpha = 0xffff, };
+static pixman_color_t inactivecolor = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
+static pixman_color_t textcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
+static pixman_color_t urgbgcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
+static pixman_color_t urgtextcolor = { .red = 2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };

--- a/config.def.h
+++ b/config.def.h
@@ -15,4 +15,4 @@ static pixman_color_t activecolor = { .red = 0x0000, .green = 0x5555, .blue = 0x
 static pixman_color_t inactivecolor = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
 static pixman_color_t textcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
 static pixman_color_t urgbgcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t urgtextcolor = { .red = 2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
+static pixman_color_t urgtextcolor = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };

--- a/config.def.h
+++ b/config.def.h
@@ -3,10 +3,11 @@ static bool hidden = false;
 static bool bottom = false;
 static bool hide_vacant = false;
 
-// define the number of tags and the tag names, if the number of tags is
-//  greater than TAGSLEN they will not be displayed, each tag also needs a name
-#define TAGSLEN 9
-static char *tags[TAGSLEN] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+// font
+static char *fontstr = "monospace:size=10";
+
+// tag names
+static char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
 // set 16-bit colors for bar
 // 8-bit color can be converted to 16-bit color by simply duplicating values e.g

--- a/dwlb.c
+++ b/dwlb.c
@@ -23,8 +23,6 @@
 #include "xdg-output-unstable-v1-protocol.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
 
-#include "config.h"
-
 #define DIE(fmt, ...)						\
 	do {							\
 		fprintf(stderr, fmt "\n", ##__VA_ARGS__);	\
@@ -50,6 +48,8 @@
 	((a) < (b) ? (a) : (b))
 #define MAX(a, b)				\
 	((a) > (b) ? (a) : (b))
+#define LENGTH(X)				\
+	(sizeof X / sizeof X[0])
 
 #define PROGRAM "dwlb"
 #define VERSION "0.1"
@@ -65,7 +65,7 @@
 	"	-inactive-color [COLOR]		specify color to indicate inactive tags or monitors\n" \
 	"	-urg-text-color [COLOR]		specify text color on urgent tags\n" \
 	"	-urg-bg-color [COLOR]		specify color of urgent tags\n"	\
-	"	-tags [TAG 1]...[TAG 9]		specify custom tag names\n" \
+	"	-tags [FIRST TAG]...[LAST TAG]	specify custom tag names\n" \
 	"Commands\n"							\
 	"	-status	[OUTPUT] [TEXT]		set status text\n"	\
 	"	-show [OUTPUT]			show bar\n"		\
@@ -122,19 +122,18 @@ static struct wl_shm *shm;
 static struct zwlr_layer_shell_v1 *layer_shell;
 static struct zxdg_output_manager_v1 *output_manager;
 
+static struct fcft_font *font;
+
 static Bar *bars = NULL;
 
-// TODO: it would be nice to have these be configurable, they seem to be set by the font currently?
+// TODO: it would be nice to have these be configurable, currently set by font
 static uint32_t height;
 static uint32_t textpadding;
 
-// TODO: these seem to be operational, unless i have misunderstood their use?
 static bool run_display = true;
 static bool ready = false;
 
-// TODO: ideally there would be a default font, if there is i can't see where it is set
-static struct fcft_font *font;
-
+#include "config.h"
 
 static void
 wl_buffer_release(void *data, struct wl_buffer *wl_buffer)
@@ -393,7 +392,7 @@ draw_frame(Bar *b)
 	uint32_t boxs = font->height / 9;
 	uint32_t boxw = font->height / 6 + 2;
 
-	for (uint32_t i = 0; i < TAGSLEN; i++) {
+	for (uint32_t i = 0; i < LENGTH(tags); i++) {
 		bool active = b->mtags & 1 << i;
 		bool occupied = b->ctags & 1 << i;
 		bool urgent = b->urg & 1 << i;
@@ -979,7 +978,6 @@ sig_handler(int sig)
 int
 main(int argc, char **argv)
 {
-	char *fontstr = "";
 	char *xdgruntimedir;
 	struct sockaddr_un sock_address;
 	Bar *b, *t;
@@ -1066,11 +1064,11 @@ main(int argc, char **argv)
 			if (parse_color(argv[i], &urgbgcolor) == -1)
 				DIE("malformed color string");
 		} else if (!strcmp(argv[i], "-tags")) {
-			if (i + TAGSLEN >= argc)
-				DIE("Option -tags requires %i arguments", TAGSLEN);
-			for (int j = 0; j < TAGSLEN; j++)
+			if (i + (int)LENGTH(tags) >= argc)
+				DIE("Option -tags requires %lu arguments", LENGTH(tags));
+			for (int j = 0; j < (int)LENGTH(tags); j++)
 				tags[j] = argv[i + 1 + j];
-			i += TAGSLEN;
+			i += LENGTH(tags);
 		} else if (!strcmp(argv[i], "-v")) {
 			fprintf(stderr, PROGRAM " " VERSION "\n");
 			return 0;

--- a/dwlb.c
+++ b/dwlb.c
@@ -23,6 +23,8 @@
 #include "xdg-output-unstable-v1-protocol.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
 
+#include "config.h"
+
 #define DIE(fmt, ...)						\
 	do {							\
 		fprintf(stderr, fmt "\n", ##__VA_ARGS__);	\
@@ -124,22 +126,11 @@ static Bar *bars = NULL;
 
 static uint32_t height;
 static uint32_t textpadding;
-static bool hidden = false;
-static bool bottom = false;
 
 static bool run_display = true;
 static bool ready = false;
-static bool hide_vacant = false;
-
-#define TAGSLEN 9
-static char *tags[TAGSLEN] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
 static struct fcft_font *font;
-static pixman_color_t activecolor = { .red = 0x0000, .green = 0x5555, .blue = 0x7777, .alpha = 0xffff, };
-static pixman_color_t inactivecolor = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
-static pixman_color_t textcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t urgbgcolor = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t urgtextcolor = { .red = 2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
 
 
 static void

--- a/dwlb.c
+++ b/dwlb.c
@@ -124,12 +124,15 @@ static struct zxdg_output_manager_v1 *output_manager;
 
 static Bar *bars = NULL;
 
+// TODO: it would be nice to have these be configurable, they seem to be set by the font currently?
 static uint32_t height;
 static uint32_t textpadding;
 
+// TODO: these seem to be operational, unless i have misunderstood their use?
 static bool run_display = true;
 static bool ready = false;
 
+// TODO: ideally there would be a default font, if there is i can't see where it is set
 static struct fcft_font *font;
 
 


### PR DESCRIPTION
Break out configurable defaults to a separate header file, such that they are easier to set to keep with the suckless philosophy. The necessary Makefile changes have been made to generate `config.h` should it not exist, such that it can be included.

All those that are unambiguously configuration options have been broken out into `config.def.h`, though there are some which either don't have obviously set values and others which seem to not be configurable. Some guidance on changes to how this is all structured is welcome.

Additionally there are TODOs marking areas where I was unsure about the use or nature of some properties, those in `dwlb.c` are the ones where an answer is required - I will look into the TODO in `config.def.h` now regarding how a hex color code should be translated to the color spec for pixman. **edit:** I have found the parse_color function which has only confused me further.

A list of configurable options listed in the usage instruction which have been moved into `config.def.h`:
- [x] hide vacant tags
- [x] hidden
- [x] bottom
- [ ] font [FONT]
- [x] text color
- [x] active color
- [x] inactive color
- [x] urgent text color
- [x] urgent border color
- [x] tags (names)

`TAGSLEN` has been included in `config.def.h` even though it is not directly configurable, since more tags than tagslen will cause them not to be displayed. Additionally I have mentioned that each tag needs a name since `dwlb` will fail to launch if each tag isn't named.

~~I am unsure if having a `TAGSLEN` unequal to 9 will cause the tags flag to fail?~~