### PR TITLE
Integer scaling using buffer_scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ dwlb -status all 'text ^bg(ff0000)^lm(foot)text^bg()^lm() text'
 
 A color command with no argument reverts to the default value. `^^` represents a single `^` character. Status commands can be disabled with `-no-status-commands`.
 
+## Scaling
+If you use scaling in Wayland, you can specify `buffer_scale` through config file or by passing it as an option (only integer values):
+```bash
+dwlb -scale 2
+```
+This will render both surface and a cursor with 2x detail. If your monitor is set to 1.25 or 1.5 scaling, setting scale to 2 will also work as compositor will downscale the buffer properly.
+
 ## Other Options
 Run `dwlb -h` for a full list of options.
 

--- a/config.def.h
+++ b/config.def.h
@@ -14,6 +14,8 @@ static bool status_commands = true;
 static bool center_title = false;
 // use title space as status text element
 static bool custom_title = false;
+// scale
+static uint32_t buffer_scale = 1;
 // font
 static char *fontstr = "monospace:size=16";
 // tag names if ipc is disabled

--- a/dwlb.c
+++ b/dwlb.c
@@ -640,7 +640,7 @@ pointer_frame(void *data, struct wl_pointer *pointer)
 			if (!active && !occupied && !urgent)
 				continue;
 		}
-		x += TEXT_WIDTH(tags[i], seat->bar->width - x, seat->bar->textpadding);
+		x += TEXT_WIDTH(tags[i], seat->bar->width - x, seat->bar->textpadding) / buffer_scale;
 	} while (seat->pointer_x >= x && ++i < tags_l);
 	
 	if (i < tags_l) {

--- a/dwlb.c
+++ b/dwlb.c
@@ -1696,6 +1696,10 @@ main(int argc, char **argv)
 					EDIE("strdup");
 			tags_l = tags_c = v;
 			i += v;
+		} else if (!strcmp(argv[i], "-scale")) {
+			if (++i >= argc)
+				DIE("Option -scale requires an argument");
+			buffer_scale = strtoul(argv[i], &argv[i] + strlen(argv[i]), 10);
 		} else if (!strcmp(argv[i], "-v")) {
 			fprintf(stderr, PROGRAM " " VERSION "\n");
 			return 0;

--- a/dwlb.c
+++ b/dwlb.c
@@ -882,12 +882,12 @@ show_bar(Bar *bar)
 		DIE("Could not create layer_surface");
 	zwlr_layer_surface_v1_add_listener(bar->layer_surface, &layer_surface_listener, bar);
 
-	zwlr_layer_surface_v1_set_size(bar->layer_surface, 0, bar->height);
+	zwlr_layer_surface_v1_set_size(bar->layer_surface, 0, bar->height / buffer_scale);
 	zwlr_layer_surface_v1_set_anchor(bar->layer_surface,
 					 (bar->bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP)
 					 | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT
 					 | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
-	zwlr_layer_surface_v1_set_exclusive_zone(bar->layer_surface, bar->height);
+	zwlr_layer_surface_v1_set_exclusive_zone(bar->layer_surface, bar->height / buffer_scale);
 	wl_surface_commit(bar->wl_surface);
 
 	bar->hidden = false;
@@ -906,7 +906,7 @@ hide_bar(Bar *bar)
 static void
 setup_bar(Bar *bar)
 {
-	bar->height = height;
+	bar->height = height * buffer_scale;
 	bar->textpadding = textpadding;
 	bar->bottom = bottom;
 	bar->hidden = hidden;

--- a/dwlb.c
+++ b/dwlb.c
@@ -584,9 +584,10 @@ pointer_enter(void *data, struct wl_pointer *pointer,
 	}
 
 	if (!cursor_image) {
-		struct wl_cursor_theme *cursor_theme = wl_cursor_theme_load(NULL, 24, shm);
+		struct wl_cursor_theme *cursor_theme = wl_cursor_theme_load(NULL, 24 * buffer_scale, shm);
 		cursor_image = wl_cursor_theme_get_cursor(cursor_theme, "left_ptr")->images[0];
 		cursor_surface = wl_compositor_create_surface(compositor);
+        wl_surface_set_buffer_scale(cursor_surface, buffer_scale);
 		wl_surface_attach(cursor_surface, wl_cursor_image_get_buffer(cursor_image), 0, 0);
 		wl_surface_commit(cursor_surface);
 	}

--- a/dwlb.c
+++ b/dwlb.c
@@ -93,6 +93,7 @@
 	"	-inactive-fg-color [COLOR]	specify background color of inactive tags or monitors\n" \
 	"	-urgent-fg-color [COLOR]	specify text color of urgent tags\n" \
 	"	-urgent-bg-color [COLOR]	specify background color of urgent tags\n" \
+	"	-scale [BUFFER_SCALE]		specify buffer scale value for integer scaling\n" \
 	"Commands\n"							\
 	"	-status	[OUTPUT] [TEXT]		set status text\n"	\
 	"	-title	[OUTPUT] [TEXT]		set title text, if -custom-title is enabled\n"	\


### PR DESCRIPTION
Hey, I like your bar quite a lot, so I decided to contribute. 

I am personally using 1.25 and 1.5 scale values on my monitors and I have noticed that your bar doesn't support scaling, so the bar looks very blurry/pixelated. If you know how scaling is organized in Wayland, there's two ways of dealing with scaling: so-called "integer scaling" and "fractional scaling". Fractional scaling is quite new, so I decided to implement integer scaling through an ability to supply `buffer_scale` value to the compositor. This allows you to render surfaces at (for example) 2x scale and the compositor will do the rest of the job by scaling it down to 1.25x or 1.5x. This is not ideal, but this is how scaling on Wayland was done before fractional scaling was introduced.

I might also create a PR that uses fractional scaling, but integer scaling is a good starting point.

Not sure if this is supposed to be a patch or PR, feel free to propose your solution.

Changelog:
* Added an ability to specify `buffer_scale`. This allows to use integer scaling for HiDPI displays.