### PR TITLE
Remove wl_pointer_set_cursor

### DIFF
--- a/dwlb.c
+++ b/dwlb.c
@@ -180,8 +180,6 @@ static struct wl_shm *shm;
 static struct zwlr_layer_shell_v1 *layer_shell;
 static struct zxdg_output_manager_v1 *output_manager;
 static struct znet_tapesoftware_dwl_wm_v1 *dwl_wm;
-static struct wl_cursor_image *cursor_image;
-static struct wl_surface *cursor_surface;
 
 static struct wl_list bar_list, seat_list;
 
@@ -583,18 +581,6 @@ pointer_enter(void *data, struct wl_pointer *pointer,
 			break;
 		}
 	}
-
-	if (!cursor_image) {
-		struct wl_cursor_theme *cursor_theme = wl_cursor_theme_load(NULL, 24 * buffer_scale, shm);
-		cursor_image = wl_cursor_theme_get_cursor(cursor_theme, "left_ptr")->images[0];
-		cursor_surface = wl_compositor_create_surface(compositor);
-        wl_surface_set_buffer_scale(cursor_surface, buffer_scale);
-		wl_surface_attach(cursor_surface, wl_cursor_image_get_buffer(cursor_image), 0, 0);
-		wl_surface_commit(cursor_surface);
-	}
-	wl_pointer_set_cursor(pointer, serial, cursor_surface,
-			      cursor_image->hotspot_x,
-			      cursor_image->hotspot_y);
 }
 
 static void


### PR DESCRIPTION
This PR fixes broken cursor theme and size: when cursor enters the dwlb surface, it gets rendered with default theme instead of user defined one. It happened because `XCURSOR_THEME` and `XCURSOR_SIZE` variables contents were not passed to `wl_cursor_theme_load`. 

But the simpler solution seems to be just removing this portion of the code. Maybe I'm missing something but I did not notice any regression.