### PR TITLE
Fix the issue where dwlb exits when an output is removed

### DIFF
--- a/dwlb.c
+++ b/dwlb.c
@@ -512,7 +512,6 @@ layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *surface,
 static void
 layer_surface_closed(void *data, struct zwlr_layer_surface_v1 *surface)
 {
-	run_display = false;
 }
 
 static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {


### PR DESCRIPTION
This PR fixes the problem mentioned in issue #39.