### PR TITLE
Implement macro for hex code colors and allow setting title color source

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1,3 +1,9 @@
+#define HEX_COLOR(hex)				\
+	{ .red   = ((hex >> 24) & 0xff) * 257,	\
+	  .green = ((hex >> 16) & 0xff) * 257,	\
+	  .blue  = ((hex >> 8) & 0xff) * 257,	\
+	  .alpha = (hex & 0xff) * 257 }
+
 // use ipc functionality
 static bool ipc = false;
 // initially hide all bars
@@ -22,15 +28,14 @@ static char *fontstr = "monospace:size=16";
 static char *tags_names[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
 // set 16-bit colors for bar
-// 8-bit color can be converted to 16-bit color by simply duplicating values e.g
-// 0x55 -> 0x5555, 0xf1 -> 0xf1f1
-static pixman_color_t active_fg_color = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t active_bg_color = { .red = 0x0000, .green = 0x5555, .blue = 0x7777, .alpha = 0xffff, };
-static pixman_color_t occupied_fg_color = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t occupied_bg_color = { .red = 0x0000, .green = 0x5555, .blue = 0x7777, .alpha = 0xffff, };
-static pixman_color_t inactive_fg_color = { .red = 0xbbbb, .green = 0xbbbb, .blue = 0xbbbb, .alpha = 0xffff, };
-static pixman_color_t inactive_bg_color = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
-static pixman_color_t urgent_fg_color = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
-static pixman_color_t urgent_bg_color = { .red = 0xeeee, .green = 0xeeee, .blue = 0xeeee, .alpha = 0xffff, };
-static pixman_color_t middle_bg_color = { .red = 0x2222, .green = 0x2222, .blue = 0x2222, .alpha = 0xffff, };
-static pixman_color_t middle_bg_color_selected = { .red = 0x0000, .green = 0x5555, .blue = 0x7777, .alpha = 0xffff, };
+// use either pixman_color_t struct or HEX_COLOR macro for 8-bit colors
+static pixman_color_t active_fg_color = HEX_COLOR(0xeeeeeeff);
+static pixman_color_t active_bg_color = HEX_COLOR(0x005577ff);
+static pixman_color_t occupied_fg_color = HEX_COLOR(0xeeeeeeff);
+static pixman_color_t occupied_bg_color = HEX_COLOR(0x005577ff);
+static pixman_color_t inactive_fg_color = HEX_COLOR(0xbbbbbbff);
+static pixman_color_t inactive_bg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t urgent_fg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t urgent_bg_color = HEX_COLOR(0xeeeeeeff);
+static pixman_color_t middle_bg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t middle_bg_color_selected = HEX_COLOR(0x005577ff);

--- a/config.def.h
+++ b/config.def.h
@@ -20,6 +20,8 @@ static bool status_commands = true;
 static bool center_title = false;
 // use title space as status text element
 static bool custom_title = false;
+// title color use active colors
+static bool active_color_title = true;
 // scale
 static uint32_t buffer_scale = 1;
 // font

--- a/dwlb.c
+++ b/dwlb.c
@@ -84,6 +84,8 @@
 	"	-no-center-title		do not center title text on bar\n" \
 	"	-custom-title			do not display window title and treat the area as another status text element; see -title command\n" \
 	"	-no-custom-title		display current window title as normal\n" \
+	"	-active-color-title		title colors will use active colors\n" \
+	"	-no-active-color-title		title colors will use inactive colors\n" \
 	"	-font [FONT]			specify a font\n"	\
 	"	-tags [NUMBER] [FIRST]...[LAST]	if ipc is disabled, specify custom tag names. If NUMBER is 0, then no tag names should be given \n" \
 	"	-vertical-padding [PIXELS]	specify vertical pixel padding above and below text\n" \
@@ -454,8 +456,8 @@ draw_frame(Bar *bar)
 	
 	x = draw_text(custom_title ? bar->title.text : bar->window_title,
 		      x, y, foreground, background,
-		      bar->sel ? &active_fg_color : &inactive_fg_color,
-		      bar->sel ? &active_bg_color : &inactive_bg_color,
+		      (bar->sel && active_color_title) ? &active_fg_color : &inactive_fg_color,
+		      (bar->sel && active_color_title) ? &active_bg_color : &inactive_bg_color,
 		      bar->width - status_width, bar->height, 0,
 		      custom_title ? bar->title.colors : NULL,
 		      custom_title ? bar->title.colors_l : 0);
@@ -1767,6 +1769,10 @@ main(int argc, char **argv)
 			custom_title = true;
 		} else if (!strcmp(argv[i], "-no-custom-title")) {
 			custom_title = false;
+		} else if (!strcmp(argv[i], "-active-color-title")) {
+			active_color_title = true;
+		} else if (!strcmp(argv[i], "-no-active-color-title")) {
+			active_color_title = false; 
 		} else if (!strcmp(argv[i], "-font")) {
 			if (++i >= argc)
 				DIE("Option -font requires an argument");


### PR DESCRIPTION
This resolves #10 by having a macro for easily setting colors using hex codes and adds the option to have the title use active/inactive colors.