### PR TITLE
fix the title centering

### DIFF
--- a/dwlb.c
+++ b/dwlb.c
@@ -442,7 +442,7 @@ draw_frame(Bar *bar)
 	uint32_t nx;
 	if (center_title) {
 		uint32_t title_width = TEXT_WIDTH(custom_title ? bar->title.text : bar->window_title, bar->width - status_width - x, 0);
-		nx = MAX(x, MIN((bar->width - title_width) / 2, bar->width - status_width - title_width));
+		nx = MAX(x, MIN(((bar->width - title_width - x - status_width) / 2) + x, bar->width - status_width - title_width));
 	} else {
 		nx = MIN(x + bar->textpadding, bar->width - status_width);
 	}


### PR DESCRIPTION
this change make the title be on the center of the area allocated to it instead of it trying to locate itself at the center of the bar
there is the difference
![20240719_18h22m14s_grim](https://github.com/user-attachments/assets/5e993d31-80ec-4163-a41c-b3977266f73d)
