### PR TITLE
Update IPC git repository link to point to the updated Codeberg READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dwl -s 'dwlb -font "monospace:size=16"'
 ```
 
 ## Ipc
-If dwl is [patched](https://github.com/djpohly/dwl/wiki/ipc) appropriately, dwlb is capable of communicating directly with dwl. When ipc is enabled with `-ipc`, dwlb does not read from stdin, and clicking tags functions as you would expect. Ipc can be disabled with `-no-ipc`.
+If dwl is [patched](https://codeberg.org/dwl/dwl-patches/src/branch/main/patches/ipc) appropriately, dwlb is capable of communicating directly with dwl. When ipc is enabled with `-ipc`, dwlb does not read from stdin, and clicking tags functions as you would expect. Ipc can be disabled with `-no-ipc`.
 
 ## Commands
 Command options send instructions to existing instances of dwlb. All commands take at least one argument to specify a bar on which to operate. This may be zxdg_output_v1 name, "all" to affect all outputs, or "selected" for the current output.


### PR DESCRIPTION
dwl-patches are now listed under the [dwl/dwl-patches repository](https://codeberg.org/dwl/dwl-patches/src/branch/main/patches/ipc) in Codeberg.

The previous wiki regarding patches [appears to be discontinued](https://codeberg.org/dwl/dwl-patches/wiki).

It might be nice to also link to the [patch instructions](https://codeberg.org/dwl/dwl-patches), but I left this out for now.