### PR TITLE
Add floating status support and visual indicator

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,0 +1,62 @@
+#define HEX_COLOR(hex)				\
+	{ .red   = ((hex >> 24) & 0xff) * 257,	\
+	  .green = ((hex >> 16) & 0xff) * 257,	\
+	  .blue  = ((hex >> 8) & 0xff) * 257,	\
+	  .alpha = (hex & 0xff) * 257 }
+
+// use ipc functionality
+static bool ipc = true;
+// initially hide all bars
+static bool hidden = false;
+// initially draw all bars at the bottom
+static bool bottom = false;
+// hide vacant tags
+static bool hide_vacant = false;
+// vertical pixel padding above and below text
+static uint32_t vertical_padding = 4;
+// allow in-line color commands in status text
+static bool status_commands = true;
+// center title text
+static bool center_title = false;
+// use title space as status text element
+static bool custom_title = false;
+// title color use active colors
+static bool active_color_title = true;
+// scale
+static uint32_t buffer_scale = 1;
+// font
+static char *fontstr = "monospace:bold:size=12.5";
+// tag names
+static char *tags_names[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+
+// set 16-bit colors for bar
+// use either pixman_color_t struct or HEX_COLOR macro for 8-bit colors
+#if 1
+static pixman_color_t active_fg_color = HEX_COLOR(0xffffffff);
+// static pixman_color_t active_bg_color = HEX_COLOR(0x005577ff);
+static pixman_color_t active_bg_color = HEX_COLOR(0x1177AAff);
+static pixman_color_t occupied_fg_color = HEX_COLOR(0xeeeeeeff);
+static pixman_color_t occupied_bg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t inactive_fg_color = HEX_COLOR(0xbbbbbbff);
+static pixman_color_t inactive_bg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t urgent_fg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t urgent_bg_color = HEX_COLOR(0xeeeeeeff);
+static pixman_color_t middle_bg_color = HEX_COLOR(0x222222ff);
+static pixman_color_t middle_bg_color_selected = HEX_COLOR(0x1177AAff);
+// static pixman_color_t middle_bg_color_selected = HEX_COLOR(0x005577ff);
+#else
+static pixman_color_t active_fg_color   = HEX_COLOR(0xeeeeeeff); // selfgcolor
+static pixman_color_t active_bg_color   = HEX_COLOR(0x2f133fff); // selbgcolor
+
+static pixman_color_t occupied_fg_color = HEX_COLOR(0xeeeeeeff); // selfgcolor
+static pixman_color_t occupied_bg_color = HEX_COLOR(0x2f133fff); // selbgcolor
+
+static pixman_color_t inactive_fg_color = HEX_COLOR(0xbbbbbbff); // normfgcolor
+static pixman_color_t inactive_bg_color = HEX_COLOR(0x1c1021ff); // normbgcolor
+
+static pixman_color_t urgent_fg_color   = HEX_COLOR(0x1c1021ff); // dark text
+static pixman_color_t urgent_bg_color   = HEX_COLOR(0x4f335fff); // selbordercolor
+
+static pixman_color_t middle_bg_color            = HEX_COLOR(0x1c1021ff); // normbgcolor
+static pixman_color_t middle_bg_color_selected  = HEX_COLOR(0x2f133fff); // selbgcolor
+#endif

--- a/dwlb.c
+++ b/dwlb.c
@@ -161,6 +161,7 @@ typedef struct {
 	CustomText title, status;
 
 	bool hidden, bottom;
+	bool floating;
 	bool redraw;
 
 	struct wl_list link;
@@ -469,7 +470,14 @@ draw_frame(Bar *bar)
 				});
 	x = nx;
 	
-	x = draw_text(custom_title ? bar->title.text : bar->window_title,
+	char *title_text = custom_title ? bar->title.text : bar->window_title;
+	char floating_title[TEXT_MAX];
+	if (bar->floating) {
+		snprintf(floating_title, sizeof(floating_title), "** %s **", title_text);
+		title_text = floating_title;
+	}
+
+	x = draw_text(title_text,
 		      x, y, foreground, foreground_mask, background,
 		      (bar->sel && active_color_title) ? &active_fg_color : &inactive_fg_color,
 		      (bar->sel && active_color_title) ? &active_bg_color : &inactive_bg_color,
@@ -985,6 +993,12 @@ static void
 dwl_wm_output_floating(void *data, struct zdwl_ipc_output_v2 *dwl_wm_output,
 	uint32_t is_floating)
 {
+	Bar *bar = (Bar *)data;
+
+	if ((is_floating != 0) != bar->floating) {
+		bar->floating = (is_floating != 0);
+		bar->redraw = true;
+	}
 }
 
 static const struct zdwl_ipc_output_v2_listener dwl_wm_output_listener = {
@@ -1007,6 +1021,7 @@ setup_bar(Bar *bar)
 	bar->textpadding = textpadding;
 	bar->bottom = bottom;
 	bar->hidden = hidden;
+	bar->floating = false;
 
 	bar->xdg_output = zxdg_output_manager_v1_get_xdg_output(output_manager, bar->wl_output);
 	if (!bar->xdg_output)


### PR DESCRIPTION
- Implement IPC floating event handler to track client state
- Wrap window title in '**' when the active client is floating

This PR adds support for the floating event from the dwl-ipc-unstable-v2 protocol. It allows dwlb to track whether the currently focused client is in floating mode and provides a visual indicator in the bar.

UI Enhancement, I modified the title drawing logic in draw_frame to wrap the window title with ** (e.g., **title**) when the client is floating, providing immediate visual feedback. Personally i find this very useful, because sometimes you accidentally toggle window to floating mode and you don't know until you shuffle dwl UI stack. 